### PR TITLE
Compatibility with Moodle 4.5 done differently.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,10 @@
 name: Moodle Plugin CI
 
-on:
-  push:
-    branches:
-      - master
+on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     services:
       postgres:
@@ -20,7 +17,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
 
       mariadb:
-        image: mariadb:10
+        image: mariadb:10.6
         env:
           MYSQL_USER: 'root'
           MYSQL_ALLOW_EMPTY_PASSWORD: 'true'
@@ -33,32 +30,36 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1', '8.2']
-        moodle-branch: ['MOODLE_311_STABLE', 'MOODLE_400_STABLE', 'MOODLE_401_STABLE', 'MOODLE_402_STABLE', 'MOODLE_403_STABLE']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3']
+        moodle-branch: ['MOODLE_401_STABLE', 'MOODLE_402_STABLE', 'MOODLE_403_STABLE', 'MOODLE_404_STABLE', 'MOODLE_405_STABLE']
         database: [pgsql]
-        include:
-          - moodle-branch: MOODLE_403_STABLE
-            database: mariadb
-            php: 8.2
         exclude:
-          - moodle-branch: MOODLE_402_STABLE
-            php: 7.4
-          - moodle-branch: MOODLE_403_STABLE
-            php: 7.4
-          - moodle-branch: MOODLE_311_STABLE
-            php: 8.1
-          - moodle-branch: MOODLE_400_STABLE
-            php: 8.1
-          - moodle-branch: MOODLE_311_STABLE
-            php: 8.2
-          - moodle-branch: MOODLE_400_STABLE
-            php: 8.2
           - moodle-branch: MOODLE_401_STABLE
             php: 8.2
+          - moodle-branch: MOODLE_401_STABLE
+            php: 8.3
+          - moodle-branch: MOODLE_402_STABLE
+            php: 7.4
+          - moodle-branch: MOODLE_402_STABLE
+            php: 8.3
+          - moodle-branch: MOODLE_403_STABLE
+            php: 7.4
+          - moodle-branch: MOODLE_403_STABLE
+            php: 8.0
+          - moodle-branch: MOODLE_403_STABLE
+            php: 8.3
+          - moodle-branch: MOODLE_404_STABLE
+            php: 7.4
+          - moodle-branch: MOODLE_404_STABLE
+            php: 8.0
+          - moodle-branch: MOODLE_405_STABLE
+            php: 7.4
+          - moodle-branch: MOODLE_405_STABLE
+            php: 8.0
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: plugin
 

--- a/classes/text_filter.php
+++ b/classes/text_filter.php
@@ -32,18 +32,10 @@ use filter_shortcodes\local\registry\plugin_registry;
 
 require_once($CFG->dirroot . '/filter/shortcodes/lib/helpers.php');
 
-if (class_exists(\core_filters\text_filter::class)) {
-    /**
-     * Parent class.
-     */
-    abstract class core_text_filter extends \core_filters\text_filter {}
+if (class_exists('\core_filters\text_filter')) {
+    class_alias('\core_filters\text_filter', 'filter_shortcodes_base_text_filter');
 } else {
-    require_once($CFG->libdir . '/filterlib.php');
-
-    /**
-     * Parent class.
-     */
-    abstract class core_text_filter extends \moodle_text_filter {}
+    class_alias('\moodle_text_filter', 'filter_shortcodes_base_text_filter');
 }
 
 /**
@@ -54,7 +46,7 @@ if (class_exists(\core_filters\text_filter::class)) {
  * @author     Frédéric Massart <fred@branchup.tech>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class text_filter extends core_text_filter {
+class text_filter extends \filter_shortcodes_base_text_filter {
 
     /** @var processor The processor. */
     private $processor;

--- a/filter.php
+++ b/filter.php
@@ -23,6 +23,5 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 class_alias(\filter_shortcodes\text_filter::class, 'filter_shortcodes');
+

--- a/tests/lib_helpers_test.php
+++ b/tests/lib_helpers_test.php
@@ -37,7 +37,7 @@ require_once($CFG->dirroot . '/filter/shortcodes/lib/helpers.php');
  * @author     Frédéric Massart <fred@branchup.tech>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class lib_helpers_test extends \advanced_testcase {
+final class lib_helpers_test extends \advanced_testcase {
 
     /**
      * Parse attributes data provider.
@@ -111,7 +111,7 @@ class lib_helpers_test extends \advanced_testcase {
      * @param array $expected The expected result.
      * @covers \filter_shortcodes_parse_attributes
      */
-    public function test_parse_attributes($attributes, $expected) {
+    public function test_parse_attributes($attributes, $expected): void {
         $this->assertEquals($expected, filter_shortcodes_parse_attributes($attributes));
     }
 
@@ -260,7 +260,7 @@ class lib_helpers_test extends \advanced_testcase {
      * @param string $expected The expected result.
      * @covers \filter_shortcodes_process_text
      */
-    public function test_process_text($text, $informant, $expected) {
+    public function test_process_text($text, $informant, $expected): void {
         $this->assertEquals($expected, filter_shortcodes_process_text($text, $informant));
     }
 
@@ -269,7 +269,7 @@ class lib_helpers_test extends \advanced_testcase {
      *
      * @covers \filter_shortcodes_definition_from_data
      */
-    public function test_filter_shortcodes_definition_from_data_invalid_code() {
+    public function test_filter_shortcodes_definition_from_data_invalid_code(): void {
         $this->expectException('invalid_parameter_exception');
         $this->expectExceptionMessage('Invalid parameter value detected');
         filter_shortcodes_definition_from_data('abc:d', []);
@@ -280,7 +280,7 @@ class lib_helpers_test extends \advanced_testcase {
      *
      * @covers \filter_shortcodes_definition_from_data
      */
-    public function test_filter_shortcodes_definition_from_data_invalid_code_too() {
+    public function test_filter_shortcodes_definition_from_data_invalid_code_too(): void {
         $this->expectException('invalid_parameter_exception');
         $this->expectExceptionMessage('Invalid parameter value detected');
         filter_shortcodes_definition_from_data('ab_c', []);
@@ -291,7 +291,7 @@ class lib_helpers_test extends \advanced_testcase {
      *
      * @covers \filter_shortcodes_definition_from_data
      */
-    public function test_filter_shortcodes_definition_from_data_invalid_callback() {
+    public function test_filter_shortcodes_definition_from_data_invalid_callback(): void {
         $this->expectException('coding_exception');
         $this->expectExceptionMessage("The callback for shortcode 'abc' is invalid.");
         filter_shortcodes_definition_from_data('abc', ['callback' => 'donot::exist']);
@@ -302,7 +302,7 @@ class lib_helpers_test extends \advanced_testcase {
      *
      * @covers \filter_shortcodes_definition_from_data
      */
-    public function test_filter_shortcodes_definition_from_data_missing_component() {
+    public function test_filter_shortcodes_definition_from_data_missing_component(): void {
         $this->expectException('coding_exception');
         $this->expectExceptionMessage("A shortcode must belong to a component.");
         filter_shortcodes_definition_from_data('abc', ['callback' => 'intval']);
@@ -313,7 +313,7 @@ class lib_helpers_test extends \advanced_testcase {
      *
      * @covers \filter_shortcodes_definition_from_data
      */
-    public function test_filter_shortcodes_definition_from_data() {
+    public function test_filter_shortcodes_definition_from_data(): void {
         $result = filter_shortcodes_definition_from_data('abc', ['callback' => 'intval', 'component' => 'b']);
         $this->assertEquals('abc', $result->shortcode);
         $this->assertEquals('intval', $result->callback);

--- a/tests/plugin_registry_test.php
+++ b/tests/plugin_registry_test.php
@@ -39,14 +39,14 @@ global $CFG;
  * @author     Frédéric Massart <fred@branchup.tech>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class plugin_registry_test extends \advanced_testcase {
+final class plugin_registry_test extends \advanced_testcase {
 
     /**
      * Get definitions.
      *
      * @covers \filter_shortcodes\local\registry\plugin_registry::get_definitions
      */
-    public function test_get_definitions() {
+    public function test_get_definitions(): void {
         $this->resetAfterTest();
         filter_set_global_state('shortcodes', TEXTFILTER_ON);
 
@@ -66,7 +66,7 @@ class plugin_registry_test extends \advanced_testcase {
      *
      * @covers \filter_shortcodes\local\registry\plugin_registry::get_handler
      */
-    public function test_get_handler() {
+    public function test_get_handler(): void {
         $this->resetAfterTest();
         filter_set_global_state('shortcodes', TEXTFILTER_ON);
 

--- a/tests/standard_processor_test.php
+++ b/tests/standard_processor_test.php
@@ -42,14 +42,14 @@ require_once($CFG->dirroot . '/filter/shortcodes/lib/helpers.php');
  * @author     Frédéric Massart <fred@branchup.tech>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class standard_processor_test extends \advanced_testcase {
+final class standard_processor_test extends \advanced_testcase {
 
     /**
      * Process.
      *
      * @covers \filter_shortcodes\local\processor\standard_processor::process
      */
-    public function test_process() {
+    public function test_process(): void {
         $this->resetAfterTest();
         $dg = $this->getDataGenerator();
         $u1 = $dg->create_user(['firstname' => 'François', 'lastname' => 'O\'Brian']);

--- a/tests/static_registry_test.php
+++ b/tests/static_registry_test.php
@@ -40,14 +40,14 @@ require_once($CFG->dirroot . '/filter/shortcodes/lib/helpers.php');
  * @author     Frédéric Massart <fred@branchup.tech>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class static_registry_test extends \advanced_testcase {
+final class static_registry_test extends \advanced_testcase {
 
     /**
      * Get definitions.
      *
      * @covers \filter_shortcodes\local\registry\static_registry::get_definitions
      */
-    public function test_get_definitions() {
+    public function test_get_definitions(): void {
         $registry = new static_registry([
             filter_shortcodes_definition_from_data('abc', ['component' => 'core', 'callback' => 'intval']),
             filter_shortcodes_definition_from_data('def', ['component' => 'filter_shortcodes', 'callback' => 'strlen']),
@@ -72,7 +72,7 @@ class static_registry_test extends \advanced_testcase {
      *
      * @covers \filter_shortcodes\local\registry\static_registry::get_handler
      */
-    public function test_get_handler() {
+    public function test_get_handler(): void {
         $noop = function($text) {
             return $text;
         };


### PR DESCRIPTION
In order not to clash with other filter plugins, the way to go should be the one in this branch.
Also, Moodle Plugin CI id updated to more modern PHP/Moodle versions.